### PR TITLE
feat(transport): support http transport

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,11 @@
+# MCP configuration
+MCP_TRANSPORT=stdio
+# Used only if MCP_TRANSPORT is set to "http" or "sse"
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
 # Prometheus Alertmanager configuration
 ALERTMANAGER_URL=http://localhost:9093
-
-# Authentication
-# basic auth
+# Basic Auth Authentication Info
 ALERTMANAGER_USERNAME=your_username
 ALERTMANAGER_PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ ALERTMANAGER_USERNAME=your_username  # optional
 ALERTMANAGER_PASSWORD=your_password  # optional
 ```
 
+#### Transport configuration
+
+You can control how the MCP server communicates with clients using the transport options and host/port settings. These can be set either with command-line flags (which take precedence) or with environment variables.
+
+- MCP_TRANSPORT: Transport mode. One of `stdio`, `http`, or `sse`. Default: `stdio`.
+- MCP_HOST: Host/interface to bind when running `http` or `sse` transports (used by the embedded uvicorn server). Default: `0.0.0.0`.
+- MCP_PORT: Port to listen on when running `http` or `sse` transports. Default: `8000`.
+
+Examples:
+
+Use environment variables to set defaults (CLI flags still override):
+
+```bash
+MCP_TRANSPORT=sse MCP_HOST=0.0.0.0 MCP_PORT=8080 python3 -m src.alertmanager_mcp_server.server
+```
+
+Or pass flags directly to override env vars:
+
+```bash
+python3 -m src.alertmanager_mcp_server.server --transport http --host 127.0.0.1 --port 9000
+```
+
+Notes:
+- The `stdio` transport communicates over standard input/output and ignores host/port.
+- The `http` (streamable HTTP) and `sse` transports are served via an ASGI app (uvicorn) so host/port are respected when using those transports.
+
 - Add the server configuration to your client configuration file. For example, for Claude Desktop:
 
 ```json


### PR DESCRIPTION
Make transport host/port configurable via env vars; add Streamable HTTP ASGI app

**Note**: This replaces #5 which was automatically closed due to branch renaming.

## Description
This PR makes transport selection and listening address configurable via environment variables and ensures the streamable-HTTP transport respects the configured host/port by serving it with an ASGI app (uvicorn), matching the SSE approach.

What this solves
- Previously the CLI defaults were hard-coded and did not honor environment variables.
- `mcp.run(transport='streamable-http')` previously could not be given host/port (the MCP library manages transport streams), so there was no easy way to control the listening socket for streamable HTTP from this repo.
- This change makes behavior consistent: both `sse` and `http` transports are served by uvicorn so host/port are controlled by the CLI or environment.

Changes made
- Code
  - Read environment variables and use them as defaults for CLI flags:
    - `MCP_TRANSPORT` → `--transport` (choices: `stdio`, `http`, `sse`), default `stdio`
    - `MCP_HOST` → `--host`, default `0.0.0.0`
    - `MCP_PORT` → `--port`, default `8000` (invalid values fall back to 8000 with a printed warning)
  - Add `create_streamable_app(mcp_server, debug=False) -> Starlette`:
    - Uses `mcp.server.streamable_http.StreamableHTTPServerTransport`.
    - Mounts the transport handler (at `/mcp`) and starts `mcp_server.run(read, write, init_opts)` inside a background task on Starlette startup.
    - Adds a shutdown handler to cancel the task and attempt transport termination.
  - Update `run_server()`:
    - `sse` and `http` transports now create Starlette apps and call `uvicorn.run(app, host=args.host, port=args.port)`, so CLI flags and env vars control listening address.
    - `stdio` still calls `mcp.run(transport='stdio')`.
  - Remove invalid `host`/`port` keyword args previously passed to `mcp.run(...)` for the `http`/streamable branch.
- Documentation
  - README.md: added a "Transport configuration" subsection documenting `MCP_TRANSPORT`, `MCP_HOST`, `MCP_PORT`, defaults and examples.
- Minor:
  - Handles invalid `MCP_PORT` values by printing a fallback message and using port `8000`.
  - Small comments clarifying behavior.

Files modified
- server.py
  - Added import of `StreamableHTTPServerTransport`.
  - Added `create_streamable_app` helper.
  - Updated argument parsing to read env vars.
  - Updated transport branches in `run_server()`.
- README.md
  - Added transport configuration docs and examples.

Behavior / compatibility notes
- CLI flags override environment variables.
- `stdio` transport ignores `host`/`port` (unchanged).
- `http` (streamable HTTP) and `sse` are served via uvicorn so `--host/--port` (or `MCP_HOST`/`MCP_PORT`) will determine the listening socket.
- No breaking API changes for external callers; internal behavior only changes how streamable HTTP is hosted.

How to try locally
- Use environment defaults:
```bash
MCP_TRANSPORT=http MCP_HOST=0.0.0.0 MCP_PORT=8080 python3 -m src.alertmanager_mcp_server.server
```
- Or override with CLI flags:
```bash
python3 -m src.alertmanager_mcp_server.server --transport sse --host 127.0.0.1 --port 9000
```

## Related Issue
<!-- If you are suggesting a new feature or change, please create an issue first -->
<!-- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)