### PR TITLE
support arm images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Enable multi-arch Docker builds (linux/amd64, linux/arm64)

## Description

This PR updates the GitHub Actions Docker workflow to support multi-architecture builds.

- **Added QEMU Support**: Integrated `docker/setup-qemu-action` to enable cross-platform build emulation.
- **Configured Platforms**: Updated the build step to target both `linux/amd64` and `linux/arm64`.

This ensures the published Docker images are natively compatible with a wider range of hardware, including Apple Silicon (M1/M2/M3) devices and ARM-based servers.

## Related Issue

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)