### PR TITLE
Fix silence API routes for get_silence and delete_silence

### DIFF
--- a/src/alertmanager_mcp_server/server.py
+++ b/src/alertmanager_mcp_server/server.py
@@ -394,7 +394,7 @@ async def post_silence(silence: Dict[str, Any]):
     dict:
         Create / update silence response from Alertmanager API.
     """
-    return make_request(method="POST", route="/api/v2/silences", json=silence)
+    return make_request(method="POST", route="/api/v2/silence", json=silence)
 
 
 @mcp.tool(description="Get a silence by its ID")

--- a/src/alertmanager_mcp_server/server.py
+++ b/src/alertmanager_mcp_server/server.py
@@ -429,7 +429,7 @@ async def delete_silence(silence_id: str):
         The response from the Alertmanager API.
     """
     return make_request(
-        method="DELETE", route=url_join("/api/v2/silences/", silence_id)
+        method="DELETE", route=url_join("/api/v2/silence/", silence_id)
     )
 
 

--- a/src/alertmanager_mcp_server/server.py
+++ b/src/alertmanager_mcp_server/server.py
@@ -394,7 +394,7 @@ async def post_silence(silence: Dict[str, Any]):
     dict:
         Create / update silence response from Alertmanager API.
     """
-    return make_request(method="POST", route="/api/v2/silence", json=silence)
+    return make_request(method="POST", route="/api/v2/silences", json=silence)
 
 
 @mcp.tool(description="Get a silence by its ID")
@@ -411,7 +411,7 @@ async def get_silence(silence_id: str):
     dict:
         The Silence object from Alertmanager instance.
     """
-    return make_request(method="GET", route=url_join("/api/v2/silences/", silence_id))
+    return make_request(method="GET", route=url_join("/api/v2/silence/", silence_id))
 
 
 @mcp.tool(description="Delete a silence by its ID")


### PR DESCRIPTION
## Description

`get_silence` and `delete_silence` were hitting `/api/v2/silences/{id}` (plural) and returning 404. The [Alertmanager API v2 spec](https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml) uses `/api/v2/silence/{id}` (singular) for single-resource operations.

## Related Issue

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
