### PR TITLE
fix: use Starlette lifespan for streamable HTTP

### DIFF
--- a/src/alertmanager_mcp_server/server.py
+++ b/src/alertmanager_mcp_server/server.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+import asyncio
 import os
 import logging
 import socket
 import signal
 import sys
+from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, List
@@ -694,14 +696,11 @@ def create_streamable_app(mcp_server: Server, *, debug: bool = False) -> Starlet
         Mount("/mcp", app=handle_mcp_request),
     ]
 
-    app = Starlette(debug=debug, routes=routes)
-
-    async def _startup() -> None:
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
         # Run the MCP server in a background asyncio task so the lifespan
         # event doesn't block. Store the task on app.state so shutdown can
         # cancel it.
-        import asyncio
-
         async def _run_mcp() -> None:
             # Create the transport-backed streams and run the MCP server
             async with transport.connect() as (read_stream, write_stream):
@@ -710,25 +709,20 @@ def create_streamable_app(mcp_server: Server, *, debug: bool = False) -> Starlet
                 )
 
         app.state._mcp_task = asyncio.create_task(_run_mcp())
-
-    async def _shutdown() -> None:
-        task = getattr(app.state, "_mcp_task", None)
-        if task:
-            task.cancel()
-            try:
-                await task
-            except Exception:
-                # Task cancelled or errored during shutdown is fine
-                pass
-
-        # Attempt to terminate the transport cleanly
         try:
-            await transport.terminate()
-        except Exception:
-            pass
+            yield
+        finally:
+            task = getattr(app.state, "_mcp_task", None)
+            if task:
+                task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
 
-    app.add_event_handler("startup", _startup)
-    app.add_event_handler("shutdown", _shutdown)
+            # Attempt to terminate the transport cleanly
+            with suppress(Exception):
+                await transport.terminate()
+
+    app = Starlette(debug=debug, routes=routes, lifespan=lifespan)
 
     return app
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,11 @@
 """Tests for the Prometheus Alertmanager MCP server functionality."""
 
+import asyncio
+from contextlib import asynccontextmanager
 import importlib
 import pytest
 import pytest_asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 
 import alertmanager_mcp_server.server as server
 
@@ -257,6 +259,7 @@ def test_setup_environment_with_basic_auth(monkeypatch):
     monkeypatch.setenv("ALERTMANAGER_USERNAME", "user")
     monkeypatch.setenv("ALERTMANAGER_PASSWORD", "pass")
     importlib.reload(server)
+    monkeypatch.setattr(server.sys.stderr, "isatty", lambda: True)
     with patch("builtins.print") as mock_print:
         assert server.setup_environment() is True
         output = " ".join(str(call) for call in mock_print.call_args_list)
@@ -268,6 +271,7 @@ def test_setup_environment_without_basic_auth(monkeypatch):
     monkeypatch.delenv("ALERTMANAGER_USERNAME", raising=False)
     monkeypatch.delenv("ALERTMANAGER_PASSWORD", raising=False)
     importlib.reload(server)
+    monkeypatch.setattr(server.sys.stderr, "isatty", lambda: True)
     with patch("builtins.print") as mock_print:
         assert server.setup_environment() is True
         output = " ".join(str(call) for call in mock_print.call_args_list)
@@ -583,9 +587,58 @@ async def test_get_alert_groups_pagination_max_count(mock_make_request):
     assert result["pagination"]["total"] == 15
 
 
+@pytest.mark.asyncio
+async def test_streamable_app_lifespan_runs_mcp_server(monkeypatch):
+    class FakeTransport:
+        def __init__(self):
+            self.terminated = False
+
+        async def handle_request(self, scope, receive, send):
+            pass
+
+        @asynccontextmanager
+        async def connect(self):
+            yield object(), object()
+
+        async def terminate(self):
+            self.terminated = True
+
+    transport = FakeTransport()
+    mcp_server = MagicMock()
+    mcp_server.create_initialization_options.return_value = {
+        "capabilities": {}
+    }
+    run_started = asyncio.Event()
+    run_cancelled = asyncio.Event()
+
+    async def run_forever(*args):
+        run_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            run_cancelled.set()
+            raise
+
+    mcp_server.run = AsyncMock(side_effect=run_forever)
+    monkeypatch.setattr(
+        server,
+        "StreamableHTTPServerTransport",
+        lambda *args, **kwargs: transport,
+    )
+
+    app = server.create_streamable_app(mcp_server)
+
+    async with app.router.lifespan_context(app):
+        await asyncio.wait_for(run_started.wait(), timeout=1)
+
+    assert run_cancelled.is_set()
+    assert transport.terminated is True
+
+
 @patch("alertmanager_mcp_server.server.setup_environment", return_value=True)
 @patch("alertmanager_mcp_server.server.mcp")
-def test_run_server_success(mock_mcp, mock_setup_env):
+def test_run_server_success(mock_mcp, mock_setup_env, monkeypatch):
+    monkeypatch.setattr(server.sys.stderr, "isatty", lambda: True)
     with patch("builtins.print") as mock_print, \
          patch("sys.argv", ["server.py"]):
         server.run_server()


### PR DESCRIPTION
Use Starlette lifespan instead of startup/shutdown event handlers.

## Description

There are no functional changes, other than converting the existing startup/shutdown to a lifespan context manager.

A new test is added, and existing tests now mock isatty as that was the only way I could get them to pass locally. I also use Pytest's monkeypatch instead of the old unittest patcher, that is now inconsistent. I do prefer the pytest one but would be OK to revert back to unittest patch if you prefer, for consistency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)